### PR TITLE
Using baseimage buildpack-deps:jessie-curl across TICK docker images

### DIFF
--- a/0.10/Dockerfile
+++ b/0.10/Dockerfile
@@ -1,11 +1,4 @@
-FROM debian:jessie
-
-RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    ca-certificates \
-    apt-transport-https \
-    gnupg \
-    wget
+FROM buildpack-deps:jessie-curl
 
 RUN wget https://repos.influxdata.com/influxdb.key && \
     gpg --import influxdb.key && \

--- a/0.11/Dockerfile
+++ b/0.11/Dockerfile
@@ -1,11 +1,4 @@
-FROM debian:jessie
-
-RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    ca-certificates \
-    apt-transport-https \
-    gnupg \
-    wget
+FROM buildpack-deps:jessie-curl
 
 RUN wget https://repos.influxdata.com/influxdb.key && \
     gpg --import influxdb.key && \


### PR DESCRIPTION
We should use the official docker hub base image `buildpack-deps:jessie-curl`. This will save around 4x 44 MB because the layer having curl, wget, ca-certificates inside is reused across the 4 TICK containers.